### PR TITLE
Missing a 's' to OMP_PLACES=threads

### DIFF
--- a/slides/03-simd-numa.tex
+++ b/slides/03-simd-numa.tex
@@ -618,7 +618,7 @@ end do
   \item Places allow you to divide up the hardware resource, so that threads can be assigned to them.
   \item Default: one place with all cores.
   \item Use \mintinline{bash}|OMP_PLACES| environment variable to control.
-  \item \mintinline{bash}|OMP_PLACES=thread|: each place is a single hardware thread.
+  \item \mintinline{bash}|OMP_PLACES=threads|: each place is a single hardware thread.
   \item \mintinline{bash}|OMP_PLACES=cores|: each place is a single core (containing one or more hardware threads).
   \item \mintinline{bash}|OMP_PLACES=sockets|: each place contains the cores of a single socket.
   \item Can also use list notation: \mintinline{bash}|OMP_PLACES="{0:4},{4:4},{8:4},{12:4}"|


### PR DESCRIPTION
According to https://www.openmp.org/spec-html/5.0/openmpse53.html